### PR TITLE
test(helpers): add NUnit tests and align structure

### DIFF
--- a/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestCollectionHelper.cs
+++ b/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestCollectionHelper.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Jaywapp.Infrastructure.Helpers;
+using NUnit.Framework;
+
+namespace Jaywapp.Infrastructure.Tests
+{
+    public class TestCollectionHelper
+    {
+        [Test]
+        public void AddRange_AddsAllItemsInOrder()
+        {
+            var list = new List<int> { 1 };
+            list.AddRange(new[] { 2, 3, 4 });
+
+            Assert.That(list, Is.EqualTo(new[] { 1, 2, 3, 4 }));
+        }
+    }
+}

--- a/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestColorHelper.cs
+++ b/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestColorHelper.cs
@@ -1,0 +1,35 @@
+using Jaywapp.Infrastructure.Helpers;
+using NUnit.Framework;
+using System.Windows.Media;
+
+namespace Jaywapp.Infrastructure.Tests
+{
+    public class TestColorHelper
+    {
+        [Test]
+        public void GetColorName_KnownColor_ReturnsName()
+        {
+            var name = Colors.Red.GetColorName();
+            Assert.That(name, Is.EqualTo("Red"));
+        }
+
+        [Test]
+        public void ToColor_ParsesStringOrReturnsDefault()
+        {
+            var c1 = "#FF0000".ToColor();
+            Assert.That(c1, Is.EqualTo(Colors.Red));
+
+            var c2 = "not-a-color".ToColor(Colors.Blue);
+            Assert.That(c2, Is.EqualTo(Colors.Blue));
+        }
+
+        [Test]
+        public void TryConvertColor_ReturnsTrueWhenParsable()
+        {
+            Assert.That("#00FF00".TryConvertColor(out var green), Is.True);
+            Assert.That(green, Is.EqualTo(Colors.Lime));
+
+            Assert.That("invalid".TryConvertColor(out _), Is.False);
+        }
+    }
+}

--- a/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestDataTableHelper.cs
+++ b/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestDataTableHelper.cs
@@ -1,0 +1,35 @@
+using System.Data;
+using System.Linq;
+using Jaywapp.Infrastructure.Helpers;
+using NUnit.Framework;
+
+namespace Jaywapp.Infrastructure.Tests
+{
+    public class TestDataTableHelper
+    {
+        [Test]
+        public void DataColumnCollection_ToList_ReturnsAllColumns()
+        {
+            var dt = new DataTable();
+            dt.Columns.Add("A");
+            dt.Columns.Add("B");
+
+            var list = dt.Columns.ToList();
+            Assert.That(list.Select(c => c.ColumnName).ToArray(), Is.EqualTo(new[] { "A", "B" }));
+        }
+
+        [Test]
+        public void DataRowCollection_ToList_ReturnsAllRows()
+        {
+            var dt = new DataTable();
+            dt.Columns.Add("A", typeof(int));
+            dt.Rows.Add(1);
+            dt.Rows.Add(2);
+
+            var rows = dt.Rows.ToList();
+            Assert.That(rows.Count, Is.EqualTo(2));
+            Assert.That((int)rows[0][0], Is.EqualTo(1));
+            Assert.That((int)rows[1][0], Is.EqualTo(2));
+        }
+    }
+}

--- a/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestEnumHelper.cs
+++ b/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestEnumHelper.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Jaywapp.Infrastructure.Helpers;
+using NUnit.Framework;
+
+namespace Jaywapp.Infrastructure.Tests
+{
+    public class TestEnumHelper
+    {
+        private enum Sample
+        {
+            [Description("Alpha")] A = 0,
+            [Description("Beta")] B = 1,
+            C = 2
+        }
+
+        [Test]
+        public void GetValues_ReturnsAllValues()
+        {
+            var vals = EnumHelper.GetValues<Sample>().ToArray();
+            Assert.That(vals, Is.EqualTo(new[] { Sample.A, Sample.B, Sample.C }));
+        }
+
+        [Test]
+        public void TryGetDescription_FindsAttribute()
+        {
+            Assert.That(EnumHelper.TryGetDescription(Sample.A, out var descA), Is.True);
+            Assert.That(descA, Is.EqualTo("Alpha"));
+            Assert.That(EnumHelper.TryGetDescription(Sample.C, out _), Is.False);
+        }
+
+        [Test]
+        public void GetDescriptionOrToString_Works()
+        {
+            Assert.That(Sample.B.GetDescriptionOrToString(), Is.EqualTo("Beta"));
+            Assert.That(Sample.C.GetDescriptionOrToString(), Is.EqualTo("C"));
+        }
+
+        [Test]
+        public void GetValueFromDescription_Parses()
+        {
+            Assert.That("Alpha".GetValueFromDescription<Sample>(), Is.EqualTo(Sample.A));
+            Assert.That("C".GetValueFromDescription<Sample>(), Is.EqualTo(Sample.C));
+        }
+
+        [Test]
+        public void TryParseValueFromDescription_ByType_Works()
+        {
+            Assert.That(EnumHelper.TryParseValueFromDescription("Beta", typeof(Sample), out var value), Is.True);
+            Assert.That(value, Is.EqualTo(Sample.B));
+            Assert.That(EnumHelper.TryParseValueFromDescription("ZZZ", typeof(Sample), out _), Is.False);
+        }
+    }
+}

--- a/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestEnumerableHelper.cs
+++ b/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestEnumerableHelper.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+using Jaywapp.Infrastructure.Helpers;
+using NUnit.Framework;
+
+namespace Jaywapp.Infrastructure.Tests
+{
+    public class TestEnumerableHelper
+    {
+        [Test]
+        public void IsNullOrEmpty_Works()
+        {
+            IEnumerable<int> nullEnum = null;
+            Assert.That(EnumerableHelper.IsNullOrEmpty(nullEnum), Is.True);
+            Assert.That(EnumerableHelper.IsNullOrEmpty(new int[0]), Is.True);
+            Assert.That(EnumerableHelper.IsNullOrEmpty(new[] { 1 }), Is.False);
+        }
+
+        [Test]
+        public void ToObservableCollection_CreatesCollectionWithItems()
+        {
+            var src = new[] { 10, 20 };
+            var oc = src.ToObservableCollection();
+            Assert.That(oc.Count, Is.EqualTo(2));
+            Assert.That(oc[0], Is.EqualTo(10));
+            Assert.That(oc[1], Is.EqualTo(20));
+        }
+
+        [Test]
+        public void ChainPairing_NonCircular_PairsSequentially()
+        {
+            var pairs = new[] { 1, 2, 3 }.ChainPairing().ToList();
+            Assert.That(pairs, Is.EqualTo(new[] { (1, 2), (2, 3) }));
+        }
+
+        [Test]
+        public void ChainPairing_Circular_IncludesWrapPair()
+        {
+            var pairs = new[] { 1, 2, 3 }.ChainPairing(isCircular: true).ToList();
+            Assert.That(pairs, Is.EqualTo(new[] { (1, 2), (2, 3), (3, 1) }));
+        }
+    }
+}

--- a/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestFileHelper.cs
+++ b/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestFileHelper.cs
@@ -1,0 +1,123 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Jaywapp.Infrastructure.Helpers;
+using NUnit.Framework;
+
+namespace Jaywapp.Infrastructure.Tests
+{
+    public class TestFileHelper
+    {
+        [Test]
+        public void ReadLines_ReadsAll()
+        {
+            var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+            try
+            {
+                var file = Path.Combine(dir.FullName, "sample.txt");
+                File.WriteAllLines(file, new[] { "a", "b", "c" });
+                var lines = file.ReadLines().ToArray();
+                Assert.That(lines, Is.EqualTo(new[] { "a", "b", "c" }));
+            }
+            finally
+            {
+                Directory.Delete(dir.FullName, true);
+            }
+        }
+
+        [Test]
+        public void ClearDirectory_DeletesAndRecreates()
+        {
+            var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+            var sub = Path.Combine(dir.FullName, "sub");
+            Directory.CreateDirectory(sub);
+            File.WriteAllText(Path.Combine(sub, "f.txt"), "x");
+
+            dir.FullName.ClearDirectory();
+
+            Assert.That(Directory.Exists(dir.FullName), Is.True);
+            Assert.That(Directory.GetFiles(dir.FullName, "*", SearchOption.AllDirectories).Length, Is.EqualTo(0));
+            Directory.Delete(dir.FullName, true);
+        }
+
+        [Test]
+        public void GetFiles_ReturnsRecursiveFiles()
+        {
+            var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+            try
+            {
+                var a = Path.Combine(dir.FullName, "a.txt");
+                var d = Directory.CreateDirectory(Path.Combine(dir.FullName, "d"));
+                var b = Path.Combine(d.FullName, "b.txt");
+                File.WriteAllText(a, "x");
+                File.WriteAllText(b, "y");
+                var files = FileHelper.GetFiles(dir.FullName);
+                Assert.That(files.Count, Is.EqualTo(2));
+                Assert.That(files.Any(p => p.EndsWith("a.txt")), Is.True);
+                Assert.That(files.Any(p => p.EndsWith("b.txt")), Is.True);
+            }
+            finally
+            {
+                Directory.Delete(dir.FullName, true);
+            }
+        }
+
+        [Test]
+        public void IsExtension_Works()
+        {
+            var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+            try
+            {
+                var a = Path.Combine(dir.FullName, "a.txt");
+                File.WriteAllText(a, "x");
+                Assert.That(FileHelper.IsExtension(a, ".txt"), Is.True);
+                Assert.That(FileHelper.IsExtension(a, ".bin"), Is.False);
+            }
+            finally
+            {
+                Directory.Delete(dir.FullName, true);
+            }
+        }
+
+        [Test]
+        public void Copy_CopiesFileToDirectory()
+        {
+            var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+            var dst = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+            try
+            {
+                var a = Path.Combine(dir.FullName, "a.txt");
+                File.WriteAllText(a, "x");
+                FileHelper.Copy(a, dst.FullName);
+                Assert.That(File.Exists(Path.Combine(dst.FullName, "a.txt")), Is.True);
+            }
+            finally
+            {
+                Directory.Delete(dir.FullName, true);
+                Directory.Delete(dst.FullName, true);
+            }
+        }
+
+        [Test]
+        public void Decompress_ExtractsZip()
+        {
+            var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+            var zip = Path.Combine(root.FullName, "t.zip");
+            var zipSrcDir = Directory.CreateDirectory(Path.Combine(root.FullName, "src"));
+            var zipOutDir = Path.Combine(root.FullName, "out");
+            try
+            {
+                File.WriteAllText(Path.Combine(zipSrcDir.FullName, "f.txt"), "hello");
+                if (File.Exists(zip)) File.Delete(zip);
+                ZipFile.CreateFromDirectory(zipSrcDir.FullName, zip);
+                zip.Decompress(zipOutDir);
+                Assert.That(File.Exists(Path.Combine(zipOutDir, "f.txt")), Is.True);
+            }
+            finally
+            {
+                Directory.Delete(root.FullName, true);
+            }
+        }
+    }
+}

--- a/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestHashSetHelper.cs
+++ b/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestHashSetHelper.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using Jaywapp.Infrastructure.Helpers;
+using NUnit.Framework;
+
+namespace Jaywapp.Infrastructure.Tests
+{
+    public class TestHashSetHelper
+    {
+        [Test]
+        public void AddRange_AddsUnique()
+        {
+            var hs = new HashSet<int> { 1 };
+            hs.AddRange(new[] { 1, 2, 3 });
+            Assert.That(hs.SetEquals(new[] { 1, 2, 3 }), Is.True);
+        }
+
+        [Test]
+        public void RemoveRange_RemovesSpecified()
+        {
+            var hs = new HashSet<int> { 1, 2, 3 };
+            hs.RemoveRange(new[] { 2, 4 });
+            Assert.That(hs.SetEquals(new[] { 1, 3 }), Is.True);
+        }
+    }
+}

--- a/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestRandomHelper.cs
+++ b/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestRandomHelper.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Drawing;
+using Jaywapp.Infrastructure.Helpers;
+using NUnit.Framework;
+
+namespace Jaywapp.Infrastructure.Tests
+{
+    public class TestRandomHelper
+    {
+        [Test]
+        public void NextIntRange_ProducesWithinRange()
+        {
+            var rnd = new Random(42);
+            var val = rnd.Next(1, 3); // underlying .NET method
+            Assert.That(val, Is.InRange(1, 2));
+        }
+
+        [Test]
+        public void NextCharacter_ReturnsPrintableAscii()
+        {
+            var rnd = new Random(1);
+            var ch = rnd.NextCharacter();
+            Assert.That((int)ch, Is.InRange(33, 125));
+        }
+
+        [Test]
+        public void NextString_LengthMatches()
+        {
+            var rnd = new Random(1);
+            var s = rnd.NextString(10);
+            Assert.That(s.Length, Is.EqualTo(10));
+        }
+
+        private enum Alpha { A, B, C }
+
+        [Test]
+        public void NextEnum_ReturnsAValidValue()
+        {
+            var rnd = new Random(2);
+            var e = rnd.Next<Alpha>();
+            Assert.That(Enum.IsDefined(typeof(Alpha), e), Is.True);
+        }
+
+        [Test]
+        public void NextColor_ReturnsColor()
+        {
+            var rnd = new Random(3);
+            Color c = rnd.NextColor();
+            Assert.Pass(); // existence test; value is random
+        }
+
+        [Test]
+        public void NextPoint_ReturnsPoint()
+        {
+            var rnd = new Random(4);
+            var p = rnd.NextPoint();
+            Assert.That(p, Is.Not.Null);
+        }
+
+        [Test]
+        public void Next_Selectors_PicksOne()
+        {
+            var rnd = new Random(5);
+            var v = rnd.Next(() => 1, () => 2, () => 3);
+            Assert.That(v, Is.AnyOf(1, 2, 3));
+        }
+    }
+}

--- a/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestXmlHelper.cs
+++ b/UnitTest/Jaywapp.Infrastructure.Tests/Helpers/TestXmlHelper.cs
@@ -1,0 +1,36 @@
+using System.Xml.Linq;
+using Jaywapp.Infrastructure.Helpers;
+using NUnit.Framework;
+
+namespace Jaywapp.Infrastructure.Tests
+{
+    public class TestXmlHelper
+    {
+        [Test]
+        public void GetAttributeValue_ReturnsValue()
+        {
+            var el = new XElement("root");
+            el.SetAttributeValue("name", "john");
+            Assert.That(el.GetAttributeValue("name"), Is.EqualTo("john"));
+            Assert.That(el.GetAttributeValue("age", "0"), Is.EqualTo("0"));
+        }
+
+        [Test]
+        public void TryGetAttributeValue_Works()
+        {
+            var el = new XElement("root");
+            Assert.That(el.TryGetAttributeValue("x", out var v1), Is.False);
+            Assert.That(v1, Is.Null);
+            el.SetAttributeValue("x", "1");
+            Assert.That(el.TryGetAttributeValue("x", out var v2), Is.True);
+            Assert.That(v2, Is.EqualTo("1"));
+        }
+
+        [Test]
+        public void GetAttributeValueOrEmpty_ReturnsEmptyWhenMissing()
+        {
+            var el = new XElement("root");
+            Assert.That(el.GetAttributeValueOrEmpty("none"), Is.EqualTo(""));
+        }
+    }
+}

--- a/UnitTest/Jaywapp.Infrastructure.Tests/Jaywapp.Infrastructure.Tests.csproj
+++ b/UnitTest/Jaywapp.Infrastructure.Tests/Jaywapp.Infrastructure.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows7.0</TargetFramework>
+    <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -19,6 +20,10 @@
 
   <ItemGroup>
     <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Jaywapp.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds NUnit tests for all Helpers (Collection/Enumerable/HashSet/Enum/DataTable/File/Random/Xml/Color). Test project updated to net6.0-windows with WPF support and project reference. Folder structure mirrors source.